### PR TITLE
feat: 7개 차트 시각화 컴포넌트 + 채팅 UI 개선 (#23)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.9.3",
         "react-syntax-highlighter": "^16.1.1",
-        "recharts": "^3.2.1",
+        "recharts": "^3.8.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.3.1"
       },
@@ -4496,6 +4497,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -5872,12 +5887,15 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
-      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
       "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
       "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
         "clsx": "^2.1.1",
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",
@@ -5927,6 +5945,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.9.3",
     "react-syntax-highlighter": "^16.1.1",
-    "recharts": "^3.2.1",
+    "recharts": "^3.8.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { useState, useEffect } from 'react';
 import Login from './pages/Login';
 import Chat from './pages/Chat';
+import AuthCallback from './pages/AuthCallback';
 import { isAuthenticated } from './utils/auth';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -24,6 +25,7 @@ function App() {
     <Router>
       <Routes>
         <Route path="/" element={<Login darkMode={darkMode} onToggleDark={() => setDarkMode(!darkMode)} />} />
+        <Route path="/auth/callback" element={<AuthCallback />} />
         <Route
           path="/chat"
           element={

--- a/src/components/chat/BurnoutChart.tsx
+++ b/src/components/chat/BurnoutChart.tsx
@@ -1,0 +1,107 @@
+interface ContributorBurnout {
+  name: string;
+  risk: string;
+  nightPercent: number;
+  weekendPercent: number;
+  hourly: number[];
+}
+
+interface BurnoutData {
+  repo: string;
+  contributors: ContributorBurnout[];
+}
+
+const RISK_CONFIG: Record<string, { color: string; bg: string }> = {
+  '높음': { color: '#ef4444', bg: '#ef444420' },
+  '주의': { color: '#f59e0b', bg: '#f59e0b20' },
+  '정상': { color: '#10b981', bg: '#10b98120' },
+};
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+
+function heatColor(value: number, max: number): string {
+  if (max === 0 || value === 0) return 'bg-gray-100 dark:bg-gray-800';
+  const ratio = value / max;
+  if (ratio > 0.7) return 'bg-red-500';
+  if (ratio > 0.4) return 'bg-amber-400';
+  if (ratio > 0.15) return 'bg-emerald-400';
+  return 'bg-emerald-200 dark:bg-emerald-900';
+}
+
+export default function BurnoutChart({ data }: { data: BurnoutData }) {
+  const globalMax = Math.max(...data.contributors.flatMap((c) => c.hourly), 1);
+
+  return (
+    <div className="my-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700">
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+        번아웃 위험도 — {data.repo}
+      </h3>
+
+      {/* Risk Badges */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        {data.contributors.map((c) => {
+          const cfg = RISK_CONFIG[c.risk] ?? RISK_CONFIG['정상'];
+          return (
+            <div
+              key={c.name}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs"
+              style={{ backgroundColor: cfg.bg, color: cfg.color }}
+            >
+              <span className="font-semibold">{c.name}</span>
+              <span>{c.risk}</span>
+              <span className="text-[10px] opacity-80">
+                야간 {c.nightPercent}% · 주말 {c.weekendPercent}%
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Heatmap */}
+      <div className="overflow-x-auto">
+        <div className="min-w-[600px]">
+          {/* Hour labels */}
+          <div className="flex gap-px ml-24 mb-1">
+            {HOURS.map((h) => (
+              <div
+                key={h}
+                className="flex-1 text-center text-[9px] text-gray-400"
+              >
+                {h % 3 === 0 ? `${h}시` : ''}
+              </div>
+            ))}
+          </div>
+
+          {/* Rows */}
+          {data.contributors.map((c) => (
+            <div key={c.name} className="flex items-center gap-1 mb-1">
+              <span className="text-xs text-gray-600 dark:text-gray-400 w-24 truncate text-right pr-2">
+                {c.name}
+              </span>
+              <div className="flex gap-px flex-1">
+                {c.hourly.map((val, h) => (
+                  <div
+                    key={h}
+                    className={`flex-1 h-5 rounded-sm ${heatColor(val, globalMax)} transition-colors`}
+                    title={`${c.name} ${h}시: ${val}커밋`}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+
+          {/* Legend */}
+          <div className="flex items-center justify-end gap-1 mt-2">
+            <span className="text-[10px] text-gray-400 mr-1">적음</span>
+            <div className="w-4 h-3 rounded-sm bg-gray-100 dark:bg-gray-800" />
+            <div className="w-4 h-3 rounded-sm bg-emerald-200 dark:bg-emerald-900" />
+            <div className="w-4 h-3 rounded-sm bg-emerald-400" />
+            <div className="w-4 h-3 rounded-sm bg-amber-400" />
+            <div className="w-4 h-3 rounded-sm bg-red-500" />
+            <span className="text-[10px] text-gray-400 ml-1">많음</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/BusFactorChart.tsx
+++ b/src/components/chat/BusFactorChart.tsx
@@ -1,0 +1,107 @@
+import {
+  PieChart, Pie, Cell, ResponsiveContainer, Tooltip,
+} from 'recharts';
+
+interface Contributor {
+  name: string;
+  commits: number;
+  percentage: number;
+}
+
+interface BusFactorData {
+  repo: string;
+  busFactor: number;
+  contributors: Contributor[];
+}
+
+const PALETTE = ['#6366f1', '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#14b8a6'];
+
+const riskColor = (bf: number) =>
+  bf >= 4 ? '#10b981' : bf >= 3 ? '#3b82f6' : bf >= 2 ? '#f59e0b' : '#ef4444';
+
+const riskLabel = (bf: number) =>
+  bf >= 4 ? '양호' : bf >= 3 ? '보통' : bf >= 2 ? '주의' : '위험';
+
+export default function BusFactorChart({ data }: { data: BusFactorData }) {
+  const color = riskColor(data.busFactor);
+
+  return (
+    <div className="my-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          Bus Factor — {data.repo}
+        </h3>
+        <span
+          className="text-xs font-bold px-2.5 py-1 rounded-full"
+          style={{ backgroundColor: color + '20', color }}
+        >
+          Bus Factor: {data.busFactor} ({riskLabel(data.busFactor)})
+        </span>
+      </div>
+
+      <div className="flex flex-col md:flex-row gap-4">
+        {/* Donut Chart */}
+        <div className="flex-1 min-h-[220px]">
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie
+                data={data.contributors}
+                dataKey="percentage"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius={55}
+                outerRadius={90}
+                paddingAngle={2}
+                strokeWidth={0}
+              >
+                {data.contributors.map((_, i) => (
+                  <Cell key={i} fill={PALETTE[i % PALETTE.length]} />
+                ))}
+              </Pie>
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const d = payload[0].payload as Contributor;
+                  return (
+                    <div className="bg-white dark:bg-gray-800 p-2.5 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs">
+                      <p className="font-semibold">{d.name}</p>
+                      <p className="text-gray-500">{d.commits}커밋 ({d.percentage}%)</p>
+                    </div>
+                  );
+                }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Contributor List */}
+        <div className="flex-1 flex flex-col justify-center gap-2">
+          {data.contributors.map((c, i) => (
+            <div key={c.name} className="flex items-center gap-2">
+              <span
+                className="w-3 h-3 rounded-full flex-shrink-0"
+                style={{ backgroundColor: PALETTE[i % PALETTE.length] }}
+              />
+              <span className="text-xs text-gray-700 dark:text-gray-300 w-24 truncate">
+                {c.name}
+              </span>
+              <div className="flex-1 h-4 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                <div
+                  className="h-full rounded-full transition-all"
+                  style={{
+                    width: `${c.percentage}%`,
+                    backgroundColor: PALETTE[i % PALETTE.length],
+                  }}
+                />
+              </div>
+              <span className="text-xs font-medium text-gray-600 dark:text-gray-400 w-16 text-right">
+                {c.percentage}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/CommitQualityChart.tsx
+++ b/src/components/chat/CommitQualityChart.tsx
@@ -1,0 +1,133 @@
+import {
+  PieChart, Pie, Cell, ResponsiveContainer, Tooltip,
+} from 'recharts';
+
+interface CommitType {
+  name: string;
+  count: number;
+}
+
+interface CommitQualityData {
+  repo: string;
+  grade: string;
+  totalCommits: number;
+  conventionalRate: number;
+  types: CommitType[];
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  feat: '#6366f1',
+  fix: '#ef4444',
+  refactor: '#8b5cf6',
+  docs: '#10b981',
+  test: '#f59e0b',
+  chore: '#64748b',
+  style: '#ec4899',
+  perf: '#14b8a6',
+  ci: '#06b6d4',
+  build: '#a855f7',
+  other: '#9ca3af',
+};
+
+const GRADE_COLORS: Record<string, string> = {
+  A: '#10b981',
+  B: '#3b82f6',
+  C: '#f59e0b',
+  D: '#f97316',
+  F: '#ef4444',
+};
+
+const fallbackColor = (name: string, i: number) =>
+  TYPE_COLORS[name.toLowerCase()] ??
+  ['#6366f1', '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6'][i % 6];
+
+export default function CommitQualityChart({ data }: { data: CommitQualityData }) {
+  const gradeColor = GRADE_COLORS[data.grade] ?? '#9ca3af';
+
+  return (
+    <div className="my-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          커밋 품질 — {data.repo}
+        </h3>
+        <span
+          className="text-xs font-bold px-2.5 py-1 rounded-full"
+          style={{ backgroundColor: gradeColor + '20', color: gradeColor }}
+        >
+          등급 {data.grade}
+        </span>
+      </div>
+
+      <div className="flex flex-col md:flex-row gap-4">
+        {/* Pie Chart */}
+        <div className="flex-1 min-h-[220px]">
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie
+                data={data.types}
+                dataKey="count"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius={45}
+                outerRadius={85}
+                paddingAngle={2}
+                strokeWidth={0}
+              >
+                {data.types.map((t, i) => (
+                  <Cell key={t.name} fill={fallbackColor(t.name, i)} />
+                ))}
+              </Pie>
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const d = payload[0].payload as CommitType;
+                  const total = data.types.reduce((s, t) => s + t.count, 0);
+                  return (
+                    <div className="bg-white dark:bg-gray-800 p-2.5 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs">
+                      <p className="font-semibold">{d.name}</p>
+                      <p className="text-gray-500">{d.count}개 ({(d.count / total * 100).toFixed(0)}%)</p>
+                    </div>
+                  );
+                }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Stats */}
+        <div className="flex-1 flex flex-col justify-center gap-3">
+          <div className="grid grid-cols-2 gap-2">
+            <div className="p-2.5 rounded-xl bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700">
+              <p className="text-[11px] text-gray-500 dark:text-gray-400">총 커밋</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white">
+                {data.totalCommits}개
+              </p>
+            </div>
+            <div className="p-2.5 rounded-xl bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700">
+              <p className="text-[11px] text-gray-500 dark:text-gray-400">Conventional 준수율</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white">
+                {data.conventionalRate}%
+              </p>
+            </div>
+          </div>
+          {data.types.map((t, i) => {
+            const total = data.types.reduce((s, x) => s + x.count, 0);
+            return (
+              <div key={t.name} className="flex items-center gap-2">
+                <span
+                  className="w-3 h-3 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: fallbackColor(t.name, i) }}
+                />
+                <span className="text-xs text-gray-700 dark:text-gray-300 flex-1">{t.name}</span>
+                <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                  {t.count}개 ({(t.count / total * 100).toFixed(0)}%)
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/CompareReposChart.tsx
+++ b/src/components/chat/CompareReposChart.tsx
@@ -1,0 +1,124 @@
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
+  ResponsiveContainer, Legend,
+} from 'recharts';
+
+interface RepoStat {
+  name: string;
+  commits: number;
+  prs: number;
+  conventionalRate: number;
+  prMergeRate: number;
+  commitGrade: string;
+}
+
+interface CompareReposData {
+  username: string;
+  repos: RepoStat[];
+}
+
+const METRIC_COLORS = {
+  commits: '#6366f1',
+  prs: '#3b82f6',
+  conventionalRate: '#10b981',
+  prMergeRate: '#f59e0b',
+};
+
+const GRADE_COLORS: Record<string, string> = {
+  A: '#10b981', B: '#3b82f6', C: '#f59e0b', D: '#f97316', F: '#ef4444',
+};
+
+export default function CompareReposChart({ data }: { data: CompareReposData }) {
+  return (
+    <div className="my-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700">
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+        레포 비교 — {data.username}
+      </h3>
+
+      {/* Activity Chart (commits & PRs) */}
+      <div className="min-h-[200px] mb-4">
+        <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-1 ml-1">활동량</p>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={data.repos}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 10 }} />
+            <Tooltip
+              content={({ active, payload, label }) => {
+                if (!active || !payload?.length) return null;
+                return (
+                  <div className="bg-white dark:bg-gray-800 p-2.5 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs">
+                    <p className="font-semibold mb-1">{label}</p>
+                    {payload.map((p) => (
+                      <p key={p.dataKey as string} style={{ color: p.color }}>
+                        {p.dataKey === 'commits' ? '커밋' : 'PR'}: {p.value}개
+                      </p>
+                    ))}
+                  </div>
+                );
+              }}
+            />
+            <Legend
+              wrapperStyle={{ fontSize: '11px' }}
+              formatter={(value: string) => (value === 'commits' ? '커밋' : 'PR')}
+            />
+            <Bar dataKey="commits" fill={METRIC_COLORS.commits} radius={[4, 4, 0, 0]} />
+            <Bar dataKey="prs" fill={METRIC_COLORS.prs} radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Quality Chart (rates) */}
+      <div className="min-h-[200px]">
+        <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-1 ml-1">품질 지표 (%)</p>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={data.repos}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+            <YAxis domain={[0, 100]} tick={{ fontSize: 10 }} tickFormatter={(v) => `${v}%`} />
+            <Tooltip
+              content={({ active, payload, label }) => {
+                if (!active || !payload?.length) return null;
+                return (
+                  <div className="bg-white dark:bg-gray-800 p-2.5 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs">
+                    <p className="font-semibold mb-1">{label}</p>
+                    {payload.map((p) => (
+                      <p key={p.dataKey as string} style={{ color: p.color }}>
+                        {p.dataKey === 'conventionalRate' ? 'Conventional 준수율' : 'PR 머지율'}:{' '}
+                        {p.value}%
+                      </p>
+                    ))}
+                  </div>
+                );
+              }}
+            />
+            <Legend
+              wrapperStyle={{ fontSize: '11px' }}
+              formatter={(value: string) =>
+                value === 'conventionalRate' ? 'Conventional 준수율' : 'PR 머지율'
+              }
+            />
+            <Bar dataKey="conventionalRate" fill={METRIC_COLORS.conventionalRate} radius={[4, 4, 0, 0]} />
+            <Bar dataKey="prMergeRate" fill={METRIC_COLORS.prMergeRate} radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Grade Badges */}
+      <div className="flex flex-wrap gap-2 mt-3">
+        {data.repos.map((r) => (
+          <span
+            key={r.name}
+            className="text-xs font-bold px-2.5 py-1 rounded-full"
+            style={{
+              backgroundColor: (GRADE_COLORS[r.commitGrade] ?? '#9ca3af') + '20',
+              color: GRADE_COLORS[r.commitGrade] ?? '#9ca3af',
+            }}
+          >
+            {r.name}: {r.commitGrade}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/DoraChart.tsx
+++ b/src/components/chat/DoraChart.tsx
@@ -1,0 +1,158 @@
+import {
+  RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar,
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell,
+  ResponsiveContainer, Legend,
+} from 'recharts';
+
+interface DoraMetric {
+  name: string;
+  value: number;
+  grade: string;
+  display: string;
+  elite: string;
+}
+
+interface DoraData {
+  metrics: DoraMetric[];
+  overall: string;
+  repo: string;
+}
+
+const GRADE_COLORS: Record<string, string> = {
+  Elite: '#10b981',
+  High: '#3b82f6',
+  Medium: '#f59e0b',
+  Low: '#ef4444',
+  'N/A': '#9ca3af',
+};
+
+const GRADE_SCORE: Record<string, number> = {
+  Elite: 100,
+  High: 75,
+  Medium: 50,
+  Low: 25,
+  'N/A': 0,
+};
+
+export default function DoraChart({ data }: { data: DoraData }) {
+  const radarData = data.metrics.map((m) => ({
+    subject: m.name,
+    score: GRADE_SCORE[m.grade] ?? 0,
+    fullMark: 100,
+  }));
+
+  const barData = data.metrics.map((m) => ({
+    name: m.name,
+    score: GRADE_SCORE[m.grade] ?? 0,
+    grade: m.grade,
+    display: m.display,
+    elite: m.elite,
+  }));
+
+  return (
+    <div className="my-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          DORA Metrics — {data.repo}
+        </h3>
+        <span
+          className="text-xs font-bold px-2.5 py-1 rounded-full"
+          style={{
+            backgroundColor: GRADE_COLORS[data.overall] + '20',
+            color: GRADE_COLORS[data.overall],
+          }}
+        >
+          {data.overall}
+        </span>
+      </div>
+
+      {/* Radar Chart */}
+      <div className="flex flex-col md:flex-row gap-4">
+        <div className="flex-1 min-h-[220px]">
+          <ResponsiveContainer width="100%" height={220}>
+            <RadarChart data={radarData}>
+              <PolarGrid stroke="#e5e7eb" />
+              <PolarAngleAxis
+                dataKey="subject"
+                tick={{ fill: '#6b7280', fontSize: 11 }}
+              />
+              <PolarRadiusAxis
+                angle={90}
+                domain={[0, 100]}
+                tick={{ fontSize: 9 }}
+                tickCount={5}
+              />
+              <Radar
+                dataKey="score"
+                stroke="#6366f1"
+                fill="#6366f1"
+                fillOpacity={0.25}
+                strokeWidth={2}
+              />
+            </RadarChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Bar Chart */}
+        <div className="flex-1 min-h-[220px]">
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={barData} layout="vertical">
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis type="number" domain={[0, 100]} tick={{ fontSize: 10 }} />
+              <YAxis
+                type="category"
+                dataKey="name"
+                width={80}
+                tick={{ fontSize: 11 }}
+              />
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const d = payload[0].payload;
+                  return (
+                    <div className="bg-white dark:bg-gray-800 p-2.5 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs">
+                      <p className="font-semibold">{d.name}</p>
+                      <p className="text-gray-500">{d.display}</p>
+                      <p style={{ color: GRADE_COLORS[d.grade] }}>
+                        등급: {d.grade}
+                      </p>
+                      <p className="text-gray-400">Elite 기준: {d.elite}</p>
+                    </div>
+                  );
+                }}
+              />
+              <Bar dataKey="score" radius={[0, 4, 4, 0]}>
+                {barData.map((entry, i) => (
+                  <Cell key={i} fill={GRADE_COLORS[entry.grade]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Metric Details */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mt-3">
+        {data.metrics.map((m) => (
+          <div
+            key={m.name}
+            className="p-2.5 rounded-xl bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700"
+          >
+            <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-0.5">
+              {m.name}
+            </p>
+            <p className="text-sm font-semibold text-gray-900 dark:text-white">
+              {m.display}
+            </p>
+            <p
+              className="text-[11px] font-medium mt-0.5"
+              style={{ color: GRADE_COLORS[m.grade] }}
+            >
+              {m.grade}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/MarkdownRenderer.tsx
+++ b/src/components/chat/MarkdownRenderer.tsx
@@ -1,81 +1,247 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import { Copy, Check } from 'lucide-react';
-import { useState } from 'react';
+import DoraChart from './DoraChart';
+import BusFactorChart from './BusFactorChart';
+import BurnoutChart from './BurnoutChart';
+import CommitQualityChart from './CommitQualityChart';
+import ReviewBottleneckChart from './ReviewBottleneckChart';
+import CompareReposChart from './CompareReposChart';
+import RoleDistributionChart from './RoleDistributionChart';
 
 interface Props {
   content: string;
 }
 
-function CodeBlock({ language, children }: { language: string; children: string }) {
-  const [copied, setCopied] = useState(false);
+function normalizeMarkdown(raw: string): string {
+  return raw
+    .replace(/([^\n])\n---/g, '$1\n\n---')
+    .replace(/---\n([^\n])/g, '---\n\n$1')
+    .replace(/([^\n-*\d])\n([-*] )/g, '$1\n\n$2')
+    .replace(/([^\n])\n(\*\*[^*]+\*\*)/g, '$1\n\n$2')
+    .replace(/(\*\*[^*]+\*\*[^\n]*)\n([-*] )/g, '$1\n\n$2');
+}
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(children);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+type ChartType = 'dora' | 'busfactor' | 'burnout' | 'commitquality' | 'reviewbottleneck' | 'comparerepos' | 'roledistr';
 
-  return (
-    <div className="group relative my-3">
-      <div className="flex items-center justify-between bg-gray-800 dark:bg-gray-900 px-4 py-2 rounded-t-lg">
-        <span className="text-2xs font-mono text-gray-400 uppercase tracking-wide">
-          {language || 'text'}
-        </span>
-        <button
-          onClick={handleCopy}
-          className="flex items-center gap-1 text-2xs text-gray-400 hover:text-white transition-colors"
-        >
-          {copied ? (
-            <><Check size={12} /> copied</>
-          ) : (
-            <><Copy size={12} /> copy</>
-          )}
-        </button>
-      </div>
-      <SyntaxHighlighter
-        style={oneDark}
-        language={language || 'text'}
-        customStyle={{
-          margin: 0,
-          borderTopLeftRadius: 0,
-          borderTopRightRadius: 0,
-          borderBottomLeftRadius: '0.5rem',
-          borderBottomRightRadius: '0.5rem',
-          fontSize: '13px',
-          lineHeight: '1.5',
-        }}
-      >
-        {children}
-      </SyntaxHighlighter>
-    </div>
-  );
+interface ChartEntry {
+  type: ChartType;
+  data: unknown;
+  index: number;
+}
+
+// Extract balanced JSON object starting from { at startIdx
+function extractBalancedJson(text: string, startIdx: number): string | null {
+  if (text[startIdx] !== '{') return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = startIdx; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) { escape = false; continue; }
+    if (ch === '\\' && inString) { escape = true; continue; }
+    if (ch === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (ch === '{' || ch === '[') depth++;
+    if (ch === '}' || ch === ']') depth--;
+    if (depth === 0) return text.substring(startIdx, i + 1);
+  }
+  return null;
+}
+
+// Chart prefix → type mapping + JSON shape validator
+const CHART_CONFIGS: { label: string; type: ChartType; validate: (d: Record<string, unknown>) => boolean }[] = [
+  {
+    label: 'DORA_CHART',
+    type: 'dora',
+    validate: (d) => !!d.repo && !!d.metrics,
+  },
+  {
+    label: 'BUSFACTOR_CHART',
+    type: 'busfactor',
+    validate: (d) => !!d.repo && !!d.contributors && d.busFactor !== undefined,
+  },
+  {
+    label: 'BURNOUT_CHART',
+    type: 'burnout',
+    validate: (d) => !!d.repo && Array.isArray(d.contributors),
+  },
+  {
+    label: 'COMMITQUALITY_CHART',
+    type: 'commitquality',
+    validate: (d) => !!d.repo && !!d.types && d.grade !== undefined,
+  },
+  {
+    label: 'REVIEWBOTTLENECK_CHART',
+    type: 'reviewbottleneck',
+    validate: (d) => !!d.repo && !!d.reviewers,
+  },
+  {
+    label: 'COMPAREREPOS_CHART',
+    type: 'comparerepos',
+    validate: (d) => !!d.repos && Array.isArray(d.repos),
+  },
+  {
+    label: 'ROLEDISTR_CHART',
+    type: 'roledistr',
+    validate: (d) => !!d.repo && !!d.roles,
+  },
+];
+
+function extractCharts(content: string): { text: string; charts: ChartEntry[] } {
+  const charts: ChartEntry[] = [];
+  let idx = 0;
+  let text = content;
+
+  // 1. Backtick code block format (DORA only — legacy)
+  text = text.replace(/```\s*chart[:\s]?dora\s*\n?([\s\S]*?)```/gi, (_match, json) => {
+    try {
+      const data = JSON.parse(json.trim());
+      if (data.repo && data.metrics) {
+        const placeholder = `\n\n<!--chart:${idx}-->\n\n`;
+        charts.push({ type: 'dora', data, index: idx++ });
+        return placeholder;
+      }
+    } catch { /* fall through */ }
+    return _match;
+  });
+
+  // 2. PREFIX_CHART format — bracket-balanced JSON extraction
+  for (const { label, type, validate } of CHART_CONFIGS) {
+    // Match "LABEL:" or "LABEL" followed by optional whitespace and {
+    const prefixRe = new RegExp(label + ':?\\s*\\{', 'g');
+    let match;
+    const replacements: { start: number; end: number; placeholder: string }[] = [];
+
+    while ((match = prefixRe.exec(text)) !== null) {
+      const jsonStart = text.indexOf('{', match.index);
+      if (jsonStart === -1) continue;
+
+      const jsonStr = extractBalancedJson(text, jsonStart);
+      if (!jsonStr) continue;
+
+      try {
+        const data = JSON.parse(jsonStr);
+        if (validate(data as Record<string, unknown>)) {
+          const placeholder = `\n\n<!--chart:${idx}-->\n\n`;
+          charts.push({ type, data, index: idx++ });
+          replacements.push({
+            start: match.index,
+            end: jsonStart + jsonStr.length,
+            placeholder,
+          });
+        }
+      } catch { /* fall through */ }
+    }
+
+    // Apply replacements in reverse order to preserve indices
+    for (let i = replacements.length - 1; i >= 0; i--) {
+      const r = replacements[i];
+      text = text.substring(0, r.start) + r.placeholder + text.substring(r.end);
+    }
+  }
+
+  // 3. "chart:dora" or "chartdora" prefix (legacy fallback)
+  text = text.replace(/chart\s*[:\s]?\s*dora\s*\n?\s*\{/gi, (match, offset) => {
+    const jsonStart = text.indexOf('{', offset);
+    if (jsonStart === -1) return match;
+    const jsonStr = extractBalancedJson(text, jsonStart);
+    if (!jsonStr) return match;
+    try {
+      const data = JSON.parse(jsonStr);
+      if (data.repo && data.metrics) {
+        const placeholder = `\n\n<!--chart:${idx}-->\n\n`;
+        charts.push({ type: 'dora', data, index: idx++ });
+        // Return placeholder for the prefix part; the JSON part is handled by substring
+        return placeholder;
+      }
+    } catch { /* fall through */ }
+    return match;
+  });
+
+  // 4. Bare DORA JSON (last resort) — look for {"repo":...,"overall":...,"metrics":...}
+  if (charts.filter((c) => c.type === 'dora').length === 0) {
+    const bareRe = /\{"repo":\s*"[^"]+"/g;
+    let bareMatch;
+    const replacements: { start: number; end: number; placeholder: string }[] = [];
+
+    while ((bareMatch = bareRe.exec(text)) !== null) {
+      const jsonStr = extractBalancedJson(text, bareMatch.index);
+      if (!jsonStr) continue;
+      try {
+        const data = JSON.parse(jsonStr);
+        if (data.repo && data.metrics && data.overall) {
+          const placeholder = `\n\n<!--chart:${idx}-->\n\n`;
+          charts.push({ type: 'dora', data, index: idx++ });
+          replacements.push({ start: bareMatch.index, end: bareMatch.index + jsonStr.length, placeholder });
+        }
+      } catch { /* fall through */ }
+    }
+
+    for (let i = replacements.length - 1; i >= 0; i--) {
+      const r = replacements[i];
+      text = text.substring(0, r.start) + r.placeholder + text.substring(r.end);
+    }
+  }
+
+  return { text, charts };
+}
+
+function renderChart(chart: ChartEntry, key: string) {
+  switch (chart.type) {
+    case 'dora':
+      return <DoraChart key={key} data={chart.data as never} />;
+    case 'busfactor':
+      return <BusFactorChart key={key} data={chart.data as never} />;
+    case 'burnout':
+      return <BurnoutChart key={key} data={chart.data as never} />;
+    case 'commitquality':
+      return <CommitQualityChart key={key} data={chart.data as never} />;
+    case 'reviewbottleneck':
+      return <ReviewBottleneckChart key={key} data={chart.data as never} />;
+    case 'comparerepos':
+      return <CompareReposChart key={key} data={chart.data as never} />;
+    case 'roledistr':
+      return <RoleDistributionChart key={key} data={chart.data as never} />;
+    default:
+      return null;
+  }
 }
 
 export default function MarkdownRenderer({ content }: Props) {
+  if (!content) return null;
+
+  const { text, charts } = extractCharts(content);
+  const normalized = normalizeMarkdown(text);
+
+  if (charts.length === 0) {
+    return (
+      <div className="prose-chat">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          {normalized}
+        </ReactMarkdown>
+      </div>
+    );
+  }
+
+  const parts = normalized.split(/<!--chart:(\d+)-->/);
+
   return (
     <div className="prose-chat">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          code({ className, children, ...props }) {
-            const match = /language-(\w+)/.exec(className || '');
-            const codeStr = String(children).replace(/\n$/, '');
+      {parts.map((part, i) => {
+        if (i % 2 === 0) {
+          return part.trim() ? (
+            <ReactMarkdown key={i} remarkPlugins={[remarkGfm]}>
+              {part}
+            </ReactMarkdown>
+          ) : null;
+        }
 
-            if (match) {
-              return <CodeBlock language={match[1]} children={codeStr} />;
-            }
+        const chartIdx = parseInt(part, 10);
+        const chart = charts.find((c) => c.index === chartIdx);
+        if (!chart) return null;
 
-            return (
-              <code className={className} {...props}>
-                {children}
-              </code>
-            );
-          },
-        }}
-      />
+        return renderChart(chart, `chart-${i}`);
+      })}
     </div>
   );
 }

--- a/src/components/chat/ReviewBottleneckChart.tsx
+++ b/src/components/chat/ReviewBottleneckChart.tsx
@@ -1,0 +1,99 @@
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell,
+  ResponsiveContainer,
+} from 'recharts';
+
+interface Reviewer {
+  name: string;
+  reviews: number;
+  avgResponseHours: number;
+}
+
+interface ReviewBottleneckData {
+  repo: string;
+  avgReviewTime: string;
+  avgMergeTime: string;
+  pendingPRs: number;
+  reviewers: Reviewer[];
+}
+
+function speedColor(hours: number): string {
+  if (hours <= 4) return '#10b981';
+  if (hours <= 12) return '#3b82f6';
+  if (hours <= 24) return '#f59e0b';
+  return '#ef4444';
+}
+
+function formatHours(h: number): string {
+  if (h < 1) return `${Math.round(h * 60)}분`;
+  if (h < 24) return `${h.toFixed(1)}시간`;
+  return `${(h / 24).toFixed(1)}일`;
+}
+
+export default function ReviewBottleneckChart({ data }: { data: ReviewBottleneckData }) {
+  const sorted = [...data.reviewers].sort((a, b) => b.avgResponseHours - a.avgResponseHours);
+
+  return (
+    <div className="my-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700">
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+        리뷰 병목 — {data.repo}
+      </h3>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-3 gap-2 mb-4">
+        <div className="p-2.5 rounded-xl bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700">
+          <p className="text-[11px] text-gray-500 dark:text-gray-400">평균 리뷰 시간</p>
+          <p className="text-sm font-semibold text-gray-900 dark:text-white">{data.avgReviewTime}</p>
+        </div>
+        <div className="p-2.5 rounded-xl bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700">
+          <p className="text-[11px] text-gray-500 dark:text-gray-400">평균 머지 시간</p>
+          <p className="text-sm font-semibold text-gray-900 dark:text-white">{data.avgMergeTime}</p>
+        </div>
+        <div className="p-2.5 rounded-xl bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700">
+          <p className="text-[11px] text-gray-500 dark:text-gray-400">대기 중 PR</p>
+          <p className="text-sm font-semibold text-gray-900 dark:text-white">{data.pendingPRs}개</p>
+        </div>
+      </div>
+
+      {/* Bar Chart */}
+      <div className="min-h-[200px]">
+        <ResponsiveContainer width="100%" height={Math.max(200, sorted.length * 40 + 40)}>
+          <BarChart data={sorted} layout="vertical">
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis
+              type="number"
+              tick={{ fontSize: 10 }}
+              tickFormatter={(v) => formatHours(v)}
+            />
+            <YAxis
+              type="category"
+              dataKey="name"
+              width={90}
+              tick={{ fontSize: 11 }}
+            />
+            <Tooltip
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null;
+                const d = payload[0].payload as Reviewer;
+                return (
+                  <div className="bg-white dark:bg-gray-800 p-2.5 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs">
+                    <p className="font-semibold">{d.name}</p>
+                    <p className="text-gray-500">리뷰 {d.reviews}건</p>
+                    <p style={{ color: speedColor(d.avgResponseHours) }}>
+                      평균 응답: {formatHours(d.avgResponseHours)}
+                    </p>
+                  </div>
+                );
+              }}
+            />
+            <Bar dataKey="avgResponseHours" radius={[0, 4, 4, 0]}>
+              {sorted.map((r, i) => (
+                <Cell key={i} fill={speedColor(r.avgResponseHours)} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/RoleDistributionChart.tsx
+++ b/src/components/chat/RoleDistributionChart.tsx
@@ -1,0 +1,123 @@
+import {
+  PieChart, Pie, Cell, ResponsiveContainer, Tooltip,
+} from 'recharts';
+
+interface Role {
+  name: string;
+  commits: number;
+  percentage: number;
+}
+
+interface RoleDistributionData {
+  repo: string;
+  username: string;
+  roles: Role[];
+}
+
+const ROLE_COLORS: Record<string, string> = {
+  feature: '#6366f1',
+  bugfix: '#ef4444',
+  fix: '#ef4444',
+  refactoring: '#8b5cf6',
+  refactor: '#8b5cf6',
+  documentation: '#10b981',
+  docs: '#10b981',
+  infrastructure: '#f59e0b',
+  infra: '#f59e0b',
+  test: '#3b82f6',
+  other: '#9ca3af',
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  feature: '기능 개발',
+  bugfix: '버그 수정',
+  fix: '버그 수정',
+  refactoring: '리팩토링',
+  refactor: '리팩토링',
+  documentation: '문서화',
+  docs: '문서화',
+  infrastructure: '인프라',
+  infra: '인프라',
+  test: '테스트',
+  other: '기타',
+};
+
+const fallbackColor = (name: string, i: number) =>
+  ROLE_COLORS[name.toLowerCase()] ??
+  ['#6366f1', '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6'][i % 6];
+
+export default function RoleDistributionChart({ data }: { data: RoleDistributionData }) {
+  return (
+    <div className="my-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700">
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+        역할 분포 — {data.repo} ({data.username})
+      </h3>
+
+      <div className="flex flex-col md:flex-row gap-4">
+        {/* Donut Chart */}
+        <div className="flex-1 min-h-[220px]">
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie
+                data={data.roles}
+                dataKey="percentage"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius={55}
+                outerRadius={90}
+                paddingAngle={2}
+                strokeWidth={0}
+              >
+                {data.roles.map((r, i) => (
+                  <Cell key={r.name} fill={fallbackColor(r.name, i)} />
+                ))}
+              </Pie>
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const d = payload[0].payload as Role;
+                  return (
+                    <div className="bg-white dark:bg-gray-800 p-2.5 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs">
+                      <p className="font-semibold">
+                        {ROLE_LABELS[d.name.toLowerCase()] ?? d.name}
+                      </p>
+                      <p className="text-gray-500">{d.commits}커밋 ({d.percentage}%)</p>
+                    </div>
+                  );
+                }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Role List */}
+        <div className="flex-1 flex flex-col justify-center gap-2">
+          {data.roles.map((r, i) => (
+            <div key={r.name} className="flex items-center gap-2">
+              <span
+                className="w-3 h-3 rounded-full flex-shrink-0"
+                style={{ backgroundColor: fallbackColor(r.name, i) }}
+              />
+              <span className="text-xs text-gray-700 dark:text-gray-300 w-20">
+                {ROLE_LABELS[r.name.toLowerCase()] ?? r.name}
+              </span>
+              <div className="flex-1 h-4 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                <div
+                  className="h-full rounded-full transition-all"
+                  style={{
+                    width: `${r.percentage}%`,
+                    backgroundColor: fallbackColor(r.name, i),
+                  }}
+                />
+              </div>
+              <span className="text-xs font-medium text-gray-600 dark:text-gray-400 w-20 text-right">
+                {r.commits}개 ({r.percentage}%)
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -25,15 +25,10 @@
 @layer components {
   /* Markdown prose styles */
   .prose-chat {
-    @apply text-[15px] leading-7;
+    @apply text-[15px] leading-relaxed;
   }
   .prose-chat p {
-    @apply mb-4 last:mb-0;
-  }
-  /* Bold text used as section headers get extra top margin */
-  .prose-chat p > strong:first-child:last-child,
-  .prose-chat p > strong:first-child {
-    @apply text-base;
+    @apply mb-3 last:mb-0;
   }
   .prose-chat h1 {
     @apply text-xl font-bold mt-5 mb-3 text-gray-900 dark:text-white;
@@ -48,7 +43,7 @@
     @apply text-sm font-semibold mt-3 mb-1 text-gray-800 dark:text-gray-200;
   }
   .prose-chat ul {
-    @apply list-disc pl-5 mb-4 space-y-1.5;
+    @apply list-disc pl-5 mb-3 space-y-1;
   }
   .prose-chat ol {
     @apply list-decimal pl-5 mb-3 space-y-1;
@@ -65,7 +60,7 @@
            text-gray-600 dark:text-gray-400 italic;
   }
   .prose-chat hr {
-    @apply border-gray-200 dark:border-gray-700 my-6;
+    @apply border-gray-200 dark:border-gray-700 my-4;
   }
   .prose-chat a {
     @apply text-brand-600 dark:text-brand-400 underline underline-offset-2

--- a/src/index.css
+++ b/src/index.css
@@ -25,10 +25,15 @@
 @layer components {
   /* Markdown prose styles */
   .prose-chat {
-    @apply text-[15px] leading-relaxed;
+    @apply text-[15px] leading-7;
   }
   .prose-chat p {
-    @apply mb-3 last:mb-0;
+    @apply mb-4 last:mb-0;
+  }
+  /* Bold text used as section headers get extra top margin */
+  .prose-chat p > strong:first-child:last-child,
+  .prose-chat p > strong:first-child {
+    @apply text-base;
   }
   .prose-chat h1 {
     @apply text-xl font-bold mt-5 mb-3 text-gray-900 dark:text-white;
@@ -43,7 +48,7 @@
     @apply text-sm font-semibold mt-3 mb-1 text-gray-800 dark:text-gray-200;
   }
   .prose-chat ul {
-    @apply list-disc pl-5 mb-3 space-y-1;
+    @apply list-disc pl-5 mb-4 space-y-1.5;
   }
   .prose-chat ol {
     @apply list-decimal pl-5 mb-3 space-y-1;
@@ -60,7 +65,7 @@
            text-gray-600 dark:text-gray-400 italic;
   }
   .prose-chat hr {
-    @apply border-gray-200 dark:border-gray-700 my-4;
+    @apply border-gray-200 dark:border-gray-700 my-6;
   }
   .prose-chat a {
     @apply text-brand-600 dark:text-brand-400 underline underline-offset-2

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -1,10 +1,11 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { Menu, Bot, Sparkles, GitBranch, Activity, FileSearch } from 'lucide-react';
+import { Menu, Bot, Sparkles, GitBranch, Activity, FileSearch, Building2, ChevronDown } from 'lucide-react';
 import ChatMessage from '../../components/chat/ChatMessage';
 import ChatInput from '../../components/chat/ChatInput';
 import Sidebar from '../../components/chat/Sidebar';
-import { chatAPI } from '../../services/api';
+import { chatAPI, userAPI } from '../../services/api';
 import { getAccessToken, logout as authLogout } from '../../utils/auth';
 import type { ChatMessage as ChatMessageType, Conversation } from '../../types';
 
@@ -45,11 +46,31 @@ export default function Chat({ darkMode, onToggleDark }: Props) {
   const [activeConvId, setActiveConvId] = useState<string | null>(null);
   const [isStreaming, setIsStreaming] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [organizations, setOrganizations] = useState<string[]>([]);
+  const [selectedOrg, setSelectedOrg] = useState<string>('');
+  const [orgDropdownOpen, setOrgDropdownOpen] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const streamingContentRef = useRef('');
 
   const activeConv = conversations.find((c) => c.id === activeConvId) || null;
   const messages = activeConv?.messages || [];
+
+  useEffect(() => {
+    const token = getAccessToken();
+    if (token) {
+      userAPI.getOrganizations(token).then((orgs) => {
+        setOrganizations(orgs);
+        const saved = localStorage.getItem('devpulse_selected_org');
+        if (saved && orgs.includes(saved)) {
+          setSelectedOrg(saved);
+        }
+      }).catch(() => {});
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedOrg) localStorage.setItem('devpulse_selected_org', selectedOrg);
+  }, [selectedOrg]);
 
   useEffect(() => {
     saveConversations(conversations);
@@ -110,16 +131,13 @@ export default function Chat({ darkMode, onToggleDark }: Props) {
 
     const convId = activeConvId || createConversation(text);
 
-    // Add user message
+    // Add user message + assistant placeholder and force immediate render
     const userMsg: ChatMessageType = {
       id: generateId(),
       role: 'user',
       content: text,
       timestamp: Date.now(),
     };
-    addMessage(convId, userMsg);
-
-    // Add placeholder assistant message
     const assistantMsg: ChatMessageType = {
       id: generateId(),
       role: 'assistant',
@@ -127,29 +145,44 @@ export default function Chat({ darkMode, onToggleDark }: Props) {
       timestamp: Date.now(),
       isStreaming: true,
     };
-    addMessage(convId, assistantMsg);
 
-    setIsStreaming(true);
+    flushSync(() => {
+      addMessage(convId, userMsg);
+      addMessage(convId, assistantMsg);
+      setIsStreaming(true);
+    });
+
     streamingContentRef.current = '';
 
+    let lastFlush = 0;
     await chatAPI.stream(
-      { message: text, githubToken: token, conversationId: convId },
+      { message: text, githubToken: token, conversationId: convId, selectedOrg: selectedOrg || undefined },
       (chunk) => {
         streamingContentRef.current += chunk;
-        updateLastAssistantMessage(convId, streamingContentRef.current, true);
+        const now = Date.now();
+        if (now - lastFlush > 50) {
+          lastFlush = now;
+          flushSync(() => {
+            updateLastAssistantMessage(convId, streamingContentRef.current, true);
+          });
+        }
       },
       () => {
-        updateLastAssistantMessage(convId, streamingContentRef.current, false);
-        setIsStreaming(false);
+        flushSync(() => {
+          updateLastAssistantMessage(convId, streamingContentRef.current, false);
+          setIsStreaming(false);
+        });
       },
       (error) => {
         console.error('Stream error:', error);
-        updateLastAssistantMessage(
-          convId,
-          streamingContentRef.current || '죄송합니다. 오류가 발생했습니다. 다시 시도해주세요.',
-          false
-        );
-        setIsStreaming(false);
+        flushSync(() => {
+          updateLastAssistantMessage(
+            convId,
+            streamingContentRef.current || '죄송합니다. 오류가 발생했습니다. 다시 시도해주세요.',
+            false
+          );
+          setIsStreaming(false);
+        });
       }
     );
   };
@@ -200,6 +233,44 @@ export default function Chat({ darkMode, onToggleDark }: Props) {
             </div>
             <span className="text-sm font-medium text-gray-700 dark:text-gray-300">DevPulse</span>
           </div>
+
+          {/* Organization Selector */}
+          {organizations.length > 0 && (
+            <div className="relative ml-auto">
+              <button
+                onClick={() => setOrgDropdownOpen(!orgDropdownOpen)}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-sm"
+              >
+                <Building2 size={14} className="text-brand-500" />
+                <span className="text-gray-700 dark:text-gray-300 max-w-[150px] truncate">
+                  {selectedOrg || '조직 선택'}
+                </span>
+                <ChevronDown size={14} className={`text-gray-400 transition-transform ${orgDropdownOpen ? 'rotate-180' : ''}`} />
+              </button>
+              {orgDropdownOpen && (
+                <>
+                  <div className="fixed inset-0 z-10" onClick={() => setOrgDropdownOpen(false)} />
+                  <div className="absolute right-0 top-full mt-1 z-20 w-56 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 max-h-64 overflow-y-auto">
+                    <button
+                      onClick={() => { setSelectedOrg(''); setOrgDropdownOpen(false); }}
+                      className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${!selectedOrg ? 'text-brand-600 dark:text-brand-400 font-medium' : 'text-gray-600 dark:text-gray-400'}`}
+                    >
+                      전체 (선택 안 함)
+                    </button>
+                    {organizations.map((org) => (
+                      <button
+                        key={org}
+                        onClick={() => { setSelectedOrg(org); setOrgDropdownOpen(false); }}
+                        className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${selectedOrg === org ? 'text-brand-600 dark:text-brand-400 font-medium' : 'text-gray-600 dark:text-gray-400'}`}
+                      >
+                        {org}
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Messages */}

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Github, Loader2, Bot, Sun, Moon, ArrowRight, Sparkles, Shield, MessageSquare } from 'lucide-react';
-import { setUser } from '../../utils/auth';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
 
 interface Props {
   darkMode: boolean;
@@ -9,31 +9,21 @@ interface Props {
 }
 
 export default function Login({ darkMode, onToggleDark }: Props) {
-  const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
-  const [token, setToken] = useState('');
 
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!token.trim()) {
-      setError('GitHub Personal Access Token을 입력해주세요.');
-      return;
-    }
-
+  const handleGitHubLogin = async () => {
     try {
       setIsLoading(true);
       setError('');
 
-      setUser({
-        id: 'user',
-        username: 'Developer',
-        accessToken: token,
-      });
-      navigate('/chat');
-    } catch {
-      setError('로그인에 실패했습니다.');
-    } finally {
+      const response = await fetch(`${API_BASE_URL}/api/auth/github`);
+      if (!response.ok) throw new Error('서버에 연결할 수 없습니다.');
+
+      const data = await response.json();
+      window.location.href = data.authUrl;
+    } catch (err) {
+      setError('GitHub 로그인을 시작할 수 없습니다. 서버가 실행 중인지 확인해주세요.');
       setIsLoading(false);
     }
   };
@@ -115,7 +105,7 @@ export default function Login({ darkMode, onToggleDark }: Props) {
         </div>
       </div>
 
-      {/* Right — Login Form */}
+      {/* Right — Login */}
       <div className="flex-1 flex items-center justify-center p-6 sm:p-8 relative">
         {/* Dark mode toggle */}
         <button
@@ -141,49 +131,26 @@ export default function Login({ darkMode, onToggleDark }: Props) {
           <div className="mb-8">
             <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">시작하기</h2>
             <p className="text-sm text-gray-500 dark:text-gray-400">
-              GitHub Personal Access Token을 입력하여 시작하세요.
+              GitHub 계정으로 로그인하여 팀 분석을 시작하세요.
             </p>
           </div>
 
-          {/* Token Form */}
-          <form onSubmit={handleLogin} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                GitHub Token
-              </label>
-              <div className="relative">
-                <div className="absolute left-3.5 top-1/2 -translate-y-1/2">
-                  <Github size={18} className="text-gray-400" />
-                </div>
-                <input
-                  type="password"
-                  value={token}
-                  onChange={(e) => { setToken(e.target.value); setError(''); }}
-                  placeholder="ghp_xxxxxxxxxxxx"
-                  className="w-full pl-11 pr-4 py-3 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500 transition-all"
-                  disabled={isLoading}
-                />
-              </div>
-              <p className="mt-2 text-2xs text-gray-400 dark:text-gray-500">
-                Token은 로컬에만 저장되며 GitHub API 호출에만 사용됩니다.
-              </p>
-            </div>
-
-            <button
-              type="submit"
-              disabled={isLoading || !token.trim()}
-              className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-brand-600 hover:bg-brand-700 text-white rounded-xl font-medium text-sm disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-200 shadow-lg shadow-brand-600/25 hover:shadow-brand-600/40"
-            >
-              {isLoading ? (
-                <Loader2 size={18} className="animate-spin" />
-              ) : (
-                <>
-                  시작하기
-                  <ArrowRight size={16} />
-                </>
-              )}
-            </button>
-          </form>
+          {/* GitHub Login Button */}
+          <button
+            onClick={handleGitHubLogin}
+            disabled={isLoading}
+            className="w-full flex items-center justify-center gap-3 px-6 py-3.5 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-xl font-medium text-sm hover:bg-gray-800 dark:hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-lg"
+          >
+            {isLoading ? (
+              <Loader2 size={20} className="animate-spin" />
+            ) : (
+              <>
+                <Github size={20} />
+                GitHub로 로그인
+                <ArrowRight size={16} />
+              </>
+            )}
+          </button>
 
           {error && (
             <div className="mt-4 p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800/50 rounded-xl">
@@ -191,14 +158,14 @@ export default function Login({ darkMode, onToggleDark }: Props) {
             </div>
           )}
 
-          {/* Token guide */}
+          {/* Info */}
           <div className="mt-8 p-4 bg-gray-50 dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-800">
-            <h3 className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Token 발급 방법</h3>
-            <ol className="text-2xs text-gray-500 dark:text-gray-400 space-y-1 list-decimal list-inside">
-              <li>GitHub Settings &rarr; Developer settings</li>
-              <li>Personal access tokens &rarr; Tokens (classic)</li>
-              <li>Generate new token &rarr; repo 권한 선택</li>
-            </ol>
+            <h3 className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">안내</h3>
+            <ul className="text-2xs text-gray-500 dark:text-gray-400 space-y-1">
+              <li>• GitHub OAuth를 통해 안전하게 로그인합니다</li>
+              <li>• 레포지토리 읽기 권한(repo, read:org)을 사용합니다</li>
+              <li>• 토큰은 로컬에만 저장되며 서버에 저장하지 않습니다</li>
+            </ul>
           </div>
         </div>
       </div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,6 +2,18 @@ import type { ChatRequest, ChatResponse } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
 
+export const userAPI = {
+  getOrganizations: async (githubToken: string): Promise<string[]> => {
+    const response = await fetch(`${API_BASE_URL}/api/user/organizations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ githubToken }),
+    });
+    if (!response.ok) throw new Error(`Failed to fetch organizations: ${response.status}`);
+    return response.json();
+  },
+};
+
 export const chatAPI = {
   send: async (request: ChatRequest): Promise<ChatResponse> => {
     const response = await fetch(`${API_BASE_URL}/api/chat`, {
@@ -40,14 +52,12 @@ export const chatAPI = {
         if (done) break;
 
         const chunk = decoder.decode(value, { stream: true });
-        // SSE format: "data:chunk\n\n"
         const lines = chunk.split('\n');
         for (const line of lines) {
           if (line.startsWith('data:')) {
             const data = line.slice(5);
             if (data) onChunk(data);
           } else if (line.length > 0 && !line.startsWith(':')) {
-            // Plain text chunk (non-SSE)
             onChunk(line);
           }
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ export interface ChatRequest {
   message: string;
   githubToken: string;
   conversationId: string;
+  selectedOrg?: string;
 }
 
 export interface ChatResponse {


### PR DESCRIPTION
## Summary
- 6개 새 차트 컴포넌트 추가 (BusFactor, Burnout, CommitQuality, ReviewBottleneck, CompareRepos, RoleDistribution)
- MarkdownRenderer를 정규식 → 괄호 매칭 기반 JSON 파서로 전면 리팩토링 (중첩 배열 지원)
- GitHub OAuth 콜백 + 조직 선택 드롭다운 + SSE 스트리밍 채팅 UI
- DoraChart + recharts 의존성 추가

## Test plan
- [ ] 7개 차트 각각 렌더링 확인
- [ ] 중첩 JSON (Burnout hourly 배열) 파싱 확인
- [ ] 조직 선택 드롭다운 동작 확인
- [ ] 다크/라이트 모드 차트 표시 확인

Closes #23