### PR TITLE
feat: 기술 스택 분석 시각화 차트 및 추천 프롬프트 추가

### DIFF
--- a/src/components/chat/MarkdownRenderer.tsx
+++ b/src/components/chat/MarkdownRenderer.tsx
@@ -7,6 +7,7 @@ import CommitQualityChart from './CommitQualityChart';
 import ReviewBottleneckChart from './ReviewBottleneckChart';
 import CompareReposChart from './CompareReposChart';
 import RoleDistributionChart from './RoleDistributionChart';
+import TechStackChart from './TechStackChart';
 
 interface Props {
   content: string;
@@ -21,7 +22,7 @@ function normalizeMarkdown(raw: string): string {
     .replace(/(\*\*[^*]+\*\*[^\n]*)\n([-*] )/g, '$1\n\n$2');
 }
 
-type ChartType = 'dora' | 'busfactor' | 'burnout' | 'commitquality' | 'reviewbottleneck' | 'comparerepos' | 'roledistr';
+type ChartType = 'dora' | 'busfactor' | 'burnout' | 'commitquality' | 'reviewbottleneck' | 'comparerepos' | 'roledistr' | 'techstack';
 
 interface ChartEntry {
   type: ChartType;
@@ -84,6 +85,11 @@ const CHART_CONFIGS: { label: string; type: ChartType; validate: (d: Record<stri
     label: 'ROLEDISTR_CHART',
     type: 'roledistr',
     validate: (d) => !!d.repo && !!d.roles,
+  },
+  {
+    label: 'TECHSTACK_CHART',
+    type: 'techstack',
+    validate: (d) => !!d.repo && Array.isArray(d.categories),
   },
 ];
 
@@ -202,6 +208,8 @@ function renderChart(chart: ChartEntry, key: string) {
       return <CompareReposChart key={key} data={chart.data as never} />;
     case 'roledistr':
       return <RoleDistributionChart key={key} data={chart.data as never} />;
+    case 'techstack':
+      return <TechStackChart key={key} data={chart.data as never} />;
     default:
       return null;
   }

--- a/src/components/chat/TechStackChart.tsx
+++ b/src/components/chat/TechStackChart.tsx
@@ -1,0 +1,100 @@
+import { ExternalLink } from 'lucide-react';
+
+interface TechItem {
+  name: string;
+  version: string;
+  docsUrl: string;
+  source: string;
+}
+
+interface TechCategory {
+  category: string;
+  items: TechItem[];
+}
+
+interface TechStackData {
+  repo: string;
+  totalCount: number;
+  categories: TechCategory[];
+}
+
+const CATEGORY_ICONS: Record<string, string> = {
+  '언어': '💬',
+  '프레임워크': '🏗️',
+  '라이브러리': '📦',
+  '빌드 도구': '🔧',
+  '데이터베이스': '🗄️',
+  '인프라': '☁️',
+};
+
+const CATEGORY_COLORS: Record<string, string> = {
+  '언어': '#6366f1',
+  '프레임워크': '#3b82f6',
+  '라이브러리': '#10b981',
+  '빌드 도구': '#f59e0b',
+  '데이터베이스': '#ef4444',
+  '인프라': '#8b5cf6',
+};
+
+export default function TechStackChart({ data }: { data: TechStackData }) {
+  return (
+    <div className="my-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          기술 스택 — {data.repo}
+        </h3>
+        <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-brand-500/10 text-brand-600 dark:text-brand-400">
+          {data.totalCount}개 기술
+        </span>
+      </div>
+
+      <div className="space-y-3">
+        {data.categories.map((cat) => {
+          const color = CATEGORY_COLORS[cat.category] ?? '#6b7280';
+          const icon = CATEGORY_ICONS[cat.category] ?? '📋';
+
+          return (
+            <div key={cat.category}>
+              <div className="flex items-center gap-1.5 mb-2">
+                <span className="text-sm">{icon}</span>
+                <span
+                  className="text-xs font-semibold"
+                  style={{ color }}
+                >
+                  {cat.category}
+                </span>
+                <span className="text-[10px] text-gray-400">({cat.items.length})</span>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+                {cat.items.map((item) => (
+                  <a
+                    key={item.name}
+                    href={item.docsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center justify-between p-2.5 rounded-xl bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 hover:border-brand-300 dark:hover:border-brand-600 transition-colors group"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-semibold text-gray-800 dark:text-gray-200 truncate">
+                        {item.name}
+                      </p>
+                      <p className="text-[10px] text-gray-400 truncate">
+                        {item.version && <span className="mr-1.5">{item.version}</span>}
+                        <span className="opacity-60">{item.source}</span>
+                      </p>
+                    </div>
+                    <ExternalLink
+                      size={12}
+                      className="flex-shrink-0 ml-2 text-gray-300 dark:text-gray-600 group-hover:text-brand-500 transition-colors"
+                    />
+                  </a>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { Menu, Bot, Sparkles, GitBranch, Activity, FileSearch, Building2, ChevronDown } from 'lucide-react';
+import { Menu, Bot, Sparkles, GitBranch, Activity, FileSearch, Building2, ChevronDown, BookOpen } from 'lucide-react';
 import ChatMessage from '../../components/chat/ChatMessage';
 import ChatInput from '../../components/chat/ChatInput';
 import Sidebar from '../../components/chat/Sidebar';
@@ -36,7 +36,7 @@ function saveConversations(conversations: Conversation[]) {
 const SUGGESTED_PROMPTS = [
   { icon: GitBranch, text: '내 레포지토리 목록 보여줘', color: 'text-blue-500' },
   { icon: Activity, text: '우리 팀 건강 상태 진단해줘', color: 'text-green-500' },
-  { icon: FileSearch, text: 'Tally-BE 작업 기록 품질 분석해줘', color: 'text-amber-500' },
+  { icon: BookOpen, text: '이 프로젝트 기술 스택 분석해줘', color: 'text-amber-500' },
   { icon: Sparkles, text: '개발 속도와 안정성 분석해줘', color: 'text-brand-500' },
 ];
 


### PR DESCRIPTION
## Summary

closes #27

BE의 `analyzeTechStack` MCP 도구(Tally-BE #45, PR #46) 결과를 FE에서 시각적으로 보여주는 **TechStackChart** 컴포넌트를 추가합니다.

## 배경

레포의 기술 스택 분석 결과를 채팅에서 텍스트로만 보여주면 가독성이 떨어집니다.
카테고리별로 그룹핑하고, 각 기술에 버전 + 공식 문서 링크를 제공하는 시각화 카드를 추가합니다.

## 변경 내역

### 신규 파일
- **`TechStackChart.tsx`** — 기술 스택 시각화 컴포넌트
  - 카테고리별 그룹핑 (언어/프레임워크/라이브러리/빌드도구/DB/인프라)
  - 카테고리별 아이콘 + 컬러 매핑
  - 각 기술 카드에 이름, 버전, 출처 표시
  - 공식 문서 링크 (클릭 시 새 탭으로 열림)
  - 다크/라이트 모드 대응
  - 반응형 (sm: 2열, 모바일: 1열)

### 수정 파일
- **`MarkdownRenderer.tsx`**
  - `ChartType`에 `'techstack'` 추가
  - `CHART_CONFIGS`에 `TECHSTACK_CHART` 타입 + validator 추가
  - `renderChart`에 `TechStackChart` 매핑 추가
  - `TechStackChart` 임포트

- **`Chat/index.tsx`**
  - 추천 프롬프트: "Tally-BE 작업 기록 품질 분석해줘" → "이 프로젝트 기술 스택 분석해줘"로 변경
  - `BookOpen` 아이콘 추가 (lucide-react)

## TechStackChart JSON 스키마

```json
{
  "repo": "Tally-lab/Tally-BE",
  "totalCount": 8,
  "categories": [
    {
      "category": "프레임워크",
      "items": [
        { "name": "Spring Boot", "version": "3.4.1", "docsUrl": "https://docs.spring.io/spring-boot/", "source": "build.gradle" }
      ]
    }
  ]
}
```

## Test plan

- [ ] TechStackChart가 카테고리별로 정상 렌더링되는지 확인
- [ ] 각 기술 카드 클릭 시 공식 문서가 새 탭으로 열리는지 확인
- [ ] 다크/라이트 모드에서 가독성 확인
- [ ] Chat 페이지 추천 프롬프트 텍스트 및 아이콘 확인
- [ ] 모바일/데스크탑 반응형 동작 확인