### PR TITLE
feat: 시각화 포함 종합 분석 리포트 페이지 구현 (#31)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Login from './pages/Login';
 import Chat from './pages/Chat';
 import Overview from './pages/Overview';
 import AuthCallback from './pages/AuthCallback';
+import Report from './pages/Report';
 import { isAuthenticated } from './utils/auth';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -43,6 +44,7 @@ function App() {
             </ProtectedRoute>
           }
         />
+        <Route path="/report/:reportId" element={<Report />} />
       </Routes>
     </Router>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -93,3 +93,30 @@
     @apply bg-gray-50 dark:bg-gray-800/30;
   }
 }
+
+/* 리포트 인쇄 최적화 */
+@media print {
+  @page {
+    size: A4;
+    margin: 15mm;
+  }
+
+  body {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+    background: white !important;
+    color: black !important;
+  }
+
+  .report-section {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Recharts SVG 색상 보장 */
+  .recharts-wrapper,
+  .recharts-surface {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+}

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -3,10 +3,10 @@ import { useNavigate } from 'react-router-dom';
 import {
   Bot, MessageSquare, Users, GitBranch, GitPullRequest,
   ExternalLink, ChevronDown, ArrowLeft, Shield, Activity,
-  Sun, Moon, Loader2,
+  Sun, Moon, Loader2, FileText,
 } from 'lucide-react';
 import TechStackChart from '../../components/chat/TechStackChart';
-import { overviewAPI, userAPI } from '../../services/api';
+import { overviewAPI, userAPI, reportAPI } from '../../services/api';
 import { getAccessToken } from '../../utils/auth';
 import type { ProjectOverview } from '../../types';
 
@@ -34,6 +34,7 @@ export default function Overview({ darkMode, onToggleDark }: Props) {
   const [repoDropdownOpen, setRepoDropdownOpen] = useState(false);
   const [data, setData] = useState<ProjectOverview | null>(null);
   const [loading, setLoading] = useState(false);
+  const [reportLoading, setReportLoading] = useState(false);
   const [error, setError] = useState('');
 
   const token = getAccessToken();
@@ -333,13 +334,34 @@ export default function Overview({ darkMode, onToggleDark }: Props) {
             )}
 
             {/* CTA */}
-            <button
-              onClick={() => navigate('/chat')}
-              className="w-full flex items-center justify-center gap-2 py-3.5 rounded-2xl bg-gradient-to-r from-brand-500 to-brand-700 text-white font-medium text-sm hover:from-brand-600 hover:to-brand-800 transition-all shadow-lg shadow-brand-500/20"
-            >
-              <MessageSquare size={16} />
-              채팅으로 자세히 분석하기
-            </button>
+            <div className="flex gap-3">
+              <button
+                onClick={() => navigate('/chat')}
+                className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-2xl bg-gradient-to-r from-brand-500 to-brand-700 text-white font-medium text-sm hover:from-brand-600 hover:to-brand-800 transition-all shadow-lg shadow-brand-500/20"
+              >
+                <MessageSquare size={16} />
+                채팅으로 자세히 분석하기
+              </button>
+              <button
+                onClick={async () => {
+                  if (!token || !selectedOrg || !selectedRepo) return;
+                  setReportLoading(true);
+                  try {
+                    const report = await reportAPI.generate(token, selectedOrg, selectedRepo);
+                    navigate(`/report/${report.reportId}`);
+                  } catch (e) {
+                    setError(e instanceof Error ? e.message : '리포트 생성 실패');
+                  } finally {
+                    setReportLoading(false);
+                  }
+                }}
+                disabled={reportLoading}
+                className="flex items-center justify-center gap-2 px-6 py-3.5 rounded-2xl border-2 border-brand-500 text-brand-600 dark:text-brand-400 font-medium text-sm hover:bg-brand-50 dark:hover:bg-brand-950/20 transition-all disabled:opacity-50"
+              >
+                {reportLoading ? <Loader2 size={16} className="animate-spin" /> : <FileText size={16} />}
+                {reportLoading ? '생성 중...' : '종합 리포트'}
+              </button>
+            </div>
           </div>
         )}
       </main>

--- a/src/pages/Report/index.tsx
+++ b/src/pages/Report/index.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Download } from 'lucide-react';
+import { reportAPI } from '../../services/api';
+import type { ReportData } from '../../types';
+import DoraChart from '../../components/chat/DoraChart';
+import BusFactorChart from '../../components/chat/BusFactorChart';
+import BurnoutChart from '../../components/chat/BurnoutChart';
+import CommitQualityChart from '../../components/chat/CommitQualityChart';
+import ReviewBottleneckChart from '../../components/chat/ReviewBottleneckChart';
+import RoleDistributionChart from '../../components/chat/RoleDistributionChart';
+import TechStackChart from '../../components/chat/TechStackChart';
+
+function ReportSection({ title, interpretation, children }: {
+  title: string;
+  interpretation?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="report-section mb-8 break-inside-avoid">
+      <h2 className="text-xl font-bold text-gray-800 mb-4 pb-2 border-b-2 border-indigo-500">
+        {title}
+      </h2>
+      <div className="mb-4">{children}</div>
+      {interpretation && (
+        <div className="bg-indigo-50 border-l-4 border-indigo-500 p-4 rounded-r-lg">
+          <p className="text-sm font-semibold text-indigo-700 mb-1">AI 해석</p>
+          <p className="text-sm text-gray-700 leading-relaxed">{interpretation}</p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ActionItemCard({ icon, title, description }: {
+  icon: string; title: string; description: string;
+}) {
+  return (
+    <div className="flex gap-3 p-3 bg-white rounded-lg border border-gray-200">
+      <span className="text-xl flex-shrink-0">{icon}</span>
+      <div>
+        <p className="font-semibold text-gray-800 text-sm">{title}</p>
+        <p className="text-gray-600 text-xs mt-0.5">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function Report() {
+  const { reportId } = useParams<{ reportId: string }>();
+  const [report, setReport] = useState<ReportData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!reportId) return;
+    reportAPI.getData(reportId)
+      .then(setReport)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [reportId]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-white">
+        <div className="text-center">
+          <div className="w-12 h-12 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-gray-600">리포트 데이터를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-white">
+        <div className="text-center">
+          <p className="text-red-500 text-lg font-semibold">리포트를 불러올 수 없습니다</p>
+          <p className="text-gray-500 mt-2">{error || '리포트가 만료되었거나 존재하지 않습니다.'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { aiDiagnosis } = report;
+  const generatedDate = report.generatedAt
+    ? new Date(report.generatedAt).toLocaleDateString('ko-KR', {
+        year: 'numeric', month: 'long', day: 'numeric',
+      })
+    : '';
+
+  const hasData = (d: unknown): boolean => {
+    if (!d || typeof d !== 'object') return false;
+    const obj = d as Record<string, unknown>;
+    if ('error' in obj || 'raw' in obj) return false;
+    if (obj.null === true || Object.keys(obj).length === 0) return false;
+    return true;
+  };
+
+  const safeChart = (d: unknown, requiredKeys: string[]): boolean => {
+    if (!hasData(d)) return false;
+    const obj = d as Record<string, unknown>;
+    return requiredKeys.every(key => {
+      const val = obj[key];
+      return val !== null && val !== undefined;
+    });
+  };
+
+  return (
+    <div className="bg-white min-h-screen" data-report-ready="true">
+      {/* 다운로드 바 (인쇄 시 숨김) */}
+      <div className="print:hidden sticky top-0 z-50 bg-white/90 backdrop-blur border-b border-gray-200">
+        <div className="max-w-[210mm] mx-auto px-8 py-3 flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-600">
+            {report.owner}/{report.repo} 리포트
+          </span>
+          <button
+            onClick={() => window.print()}
+            className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"
+          >
+            <Download size={16} />
+            PDF로 저장
+          </button>
+        </div>
+      </div>
+
+      <div className="max-w-[210mm] mx-auto px-8 py-10 print:px-0 print:py-0">
+
+        {/* 커버 */}
+        <header className="text-center mb-12 pb-8 border-b-2 border-gray-200 break-after-avoid">
+          <div className="inline-block bg-indigo-600 text-white px-4 py-1.5 rounded-full text-sm font-medium mb-4">
+            Engineering Intelligence Report
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+            {report.owner}/{report.repo}
+          </h1>
+          <p className="text-gray-500">
+            {generatedDate} 생성 · 최근 {report.analysisPeriodDays}일 분석
+          </p>
+        </header>
+
+        {/* Executive Summary */}
+        <section className="mb-10 break-inside-avoid">
+          <h2 className="text-xl font-bold text-gray-800 mb-4 pb-2 border-b-2 border-indigo-500">
+            Executive Summary
+          </h2>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <SummaryCard
+              label="DORA 등급"
+              value={extractDoraOverall(report.dora)}
+              color="indigo"
+            />
+            <SummaryCard
+              label="Bus Factor"
+              value={extractBusFactor(report.busFactor)}
+              color="amber"
+            />
+            <SummaryCard
+              label="커밋 품질"
+              value={extractCommitGrade(report.commitQuality)}
+              color="emerald"
+            />
+            <SummaryCard
+              label="리뷰 대기 PR"
+              value={extractPendingPRs(report.reviewBottleneck)}
+              color="rose"
+            />
+          </div>
+        </section>
+
+        {/* DORA 메트릭 */}
+        {safeChart(report.dora, ['metrics', 'overall']) && (
+          <ReportSection title="개발 속도와 안정성 (DORA)" interpretation={aiDiagnosis?.doraInterpretation}>
+            <DoraChart data={report.dora as never} />
+          </ReportSection>
+        )}
+
+        {/* Bus Factor */}
+        {safeChart(report.busFactor, ['busFactor', 'contributors']) && (
+          <ReportSection title="코드 의존도 (Bus Factor)" interpretation={aiDiagnosis?.busFactorInterpretation}>
+            <BusFactorChart data={report.busFactor as never} />
+          </ReportSection>
+        )}
+
+        {/* 번아웃 위험도 */}
+        {safeChart(report.burnout, ['contributors']) && (
+          <ReportSection title="야근/과로 위험도" interpretation={aiDiagnosis?.burnoutInterpretation}>
+            <BurnoutChart data={report.burnout as never} />
+          </ReportSection>
+        )}
+
+        {/* 커밋 품질 */}
+        {safeChart(report.commitQuality, ['grade', 'types']) && (
+          <ReportSection title="작업 기록 품질" interpretation={aiDiagnosis?.commitQualityInterpretation}>
+            <CommitQualityChart data={report.commitQuality as never} />
+          </ReportSection>
+        )}
+
+        {/* 리뷰 병목 */}
+        {safeChart(report.reviewBottleneck, ['reviewers']) && (
+          <ReportSection title="코드 리뷰 대기 현황" interpretation={aiDiagnosis?.reviewBottleneckInterpretation}>
+            <ReviewBottleneckChart data={report.reviewBottleneck as never} />
+          </ReportSection>
+        )}
+
+        {/* 기술 스택 */}
+        {safeChart(report.techStack, ['categories']) && (
+          <ReportSection title="기술 스택">
+            <TechStackChart data={report.techStack as never} />
+          </ReportSection>
+        )}
+
+        {/* 역할 분포 */}
+        {safeChart(report.roleDistribution, ['roles']) && (
+          <ReportSection title="작업 유형 분포">
+            <RoleDistributionChart data={report.roleDistribution as never} />
+          </ReportSection>
+        )}
+
+        {/* AI 종합 진단 */}
+        {aiDiagnosis && (
+          <section className="mb-8 break-inside-avoid">
+            <h2 className="text-xl font-bold text-gray-800 mb-4 pb-2 border-b-2 border-indigo-500">
+              AI 종합 진단 & 액션 아이템
+            </h2>
+
+            {aiDiagnosis.immediateActions?.length > 0 && (
+              <div className="mb-4">
+                <h3 className="text-sm font-bold text-red-600 mb-2">즉시 조치 필요</h3>
+                <div className="space-y-2">
+                  {aiDiagnosis.immediateActions.map((item, i) => (
+                    <ActionItemCard key={i} {...item} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {aiDiagnosis.improvements?.length > 0 && (
+              <div className="mb-4">
+                <h3 className="text-sm font-bold text-amber-600 mb-2">개선 권고</h3>
+                <div className="space-y-2">
+                  {aiDiagnosis.improvements.map((item, i) => (
+                    <ActionItemCard key={i} {...item} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {aiDiagnosis.strengths?.length > 0 && (
+              <div className="mb-4">
+                <h3 className="text-sm font-bold text-emerald-600 mb-2">잘하고 있는 점</h3>
+                <div className="space-y-2">
+                  {aiDiagnosis.strengths.map((item, i) => (
+                    <ActionItemCard key={i} {...item} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* 푸터 */}
+        <footer className="text-center text-gray-400 text-xs pt-8 border-t border-gray-200 mt-12">
+          Generated by DevPulse · Tally-lab · {generatedDate}
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+// --- Summary Card ---
+
+function SummaryCard({ label, value, color }: { label: string; value: string; color: string }) {
+  const colorMap: Record<string, string> = {
+    indigo: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+    amber: 'bg-amber-50 text-amber-700 border-amber-200',
+    emerald: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    rose: 'bg-rose-50 text-rose-700 border-rose-200',
+  };
+  return (
+    <div className={`rounded-xl border p-4 text-center ${colorMap[color] || colorMap.indigo}`}>
+      <p className="text-xs font-medium opacity-70 mb-1">{label}</p>
+      <p className="text-2xl font-bold">{value}</p>
+    </div>
+  );
+}
+
+// --- 데이터 추출 헬퍼 ---
+
+function extractDoraOverall(dora: unknown): string {
+  if (!dora || typeof dora !== 'object') return 'N/A';
+  const d = dora as Record<string, unknown>;
+  if (d.overall) return String(d.overall);
+  if (d.raw) return 'N/A';
+  return 'N/A';
+}
+
+function extractBusFactor(bf: unknown): string {
+  if (!bf || typeof bf !== 'object') return 'N/A';
+  const d = bf as Record<string, unknown>;
+  if (d.busFactor !== undefined) return `${d.busFactor}명`;
+  if (d.raw) return 'N/A';
+  return 'N/A';
+}
+
+function extractCommitGrade(cq: unknown): string {
+  if (!cq || typeof cq !== 'object') return 'N/A';
+  const d = cq as Record<string, unknown>;
+  if (d.grade) return String(d.grade);
+  if (d.raw) return 'N/A';
+  return 'N/A';
+}
+
+function extractPendingPRs(rb: unknown): string {
+  if (!rb || typeof rb !== 'object') return 'N/A';
+  const d = rb as Record<string, unknown>;
+  if (d.pendingPRs !== undefined) return `${d.pendingPRs}개`;
+  if (d.raw) return 'N/A';
+  return 'N/A';
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,4 @@
-import type { ChatRequest, ChatResponse, ProjectOverview } from '../types';
+import type { ChatRequest, ChatResponse, ProjectOverview, ReportData } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
 
@@ -82,5 +82,34 @@ export const chatAPI = {
     await fetch(`${API_BASE_URL}/api/chat/conversations/${conversationId}`, {
       method: 'DELETE',
     });
+  },
+};
+
+export const reportAPI = {
+  generate: async (githubToken: string, owner: string, repo: string): Promise<ReportData> => {
+    const response = await fetch(`${API_BASE_URL}/api/report/${owner}/${repo}/generate`, {
+      method: 'POST',
+      headers: { 'X-GitHub-Token': githubToken },
+    });
+    if (!response.ok) throw new Error(`Report generation failed: ${response.status}`);
+    return response.json();
+  },
+
+  getData: async (reportId: string): Promise<ReportData> => {
+    const response = await fetch(`${API_BASE_URL}/api/report/${reportId}/data`);
+    if (!response.ok) throw new Error(`Report not found: ${response.status}`);
+    return response.json();
+  },
+
+  downloadPdf: async (reportId: string): Promise<void> => {
+    const response = await fetch(`${API_BASE_URL}/api/report/${reportId}/pdf`);
+    if (!response.ok) throw new Error(`PDF download failed: ${response.status}`);
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `DevPulse-Report-${reportId}.pdf`;
+    a.click();
+    URL.revokeObjectURL(url);
   },
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,3 +62,35 @@ export interface ProjectOverview {
     }[];
   };
 }
+
+export interface ReportData {
+  reportId: string;
+  owner: string;
+  repo: string;
+  generatedAt: string;
+  analysisPeriodDays: number;
+  dora: unknown;
+  busFactor: unknown;
+  burnout: unknown;
+  commitQuality: unknown;
+  reviewBottleneck: unknown;
+  roleDistribution: unknown;
+  techStack: unknown;
+  recentActivity: unknown;
+  aiDiagnosis: {
+    doraInterpretation: string;
+    busFactorInterpretation: string;
+    burnoutInterpretation: string;
+    commitQualityInterpretation: string;
+    reviewBottleneckInterpretation: string;
+    immediateActions: ActionItem[];
+    improvements: ActionItem[];
+    strengths: ActionItem[];
+  };
+}
+
+export interface ActionItem {
+  icon: string;
+  title: string;
+  description: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 5174,
+  },
 })


### PR DESCRIPTION
## Summary

- 기존 차트 컴포넌트 8개(DORA, BusFactor, Burnout, CommitQuality, ReviewBottleneck, RoleDistribution, TechStack)를 재사용한 리포트 전용 페이지
- A4 레이아웃 + 인쇄 최적화 CSS로 브라우저 PDF 다운로드 지원
- Overview 페이지에 "종합 리포트" 생성 버튼 추가

## 변경 사항

| 파일 | 내용 |
|------|------|
| `pages/Report/index.tsx` | 리포트 페이지 (커버 + 8섹션 + AI 진단 + PDF 저장) |
| `services/api.ts` | reportAPI (generate, getData, downloadPdf) |
| `types/index.ts` | ReportData, ActionItem 타입 |
| `App.tsx` | /report/:reportId 라우트 추가 |
| `pages/Overview/index.tsx` | "종합 리포트" 버튼 추가 |
| `index.css` | @media print A4 인쇄 최적화 |
| `vite.config.ts` | dev 서버 포트 5174 고정 |

## 리포트 구성

1. **커버**: 프로젝트명, 생성일, 분석 기간
2. **Executive Summary**: DORA 등급, Bus Factor, 커밋 품질, 리뷰 대기 PR
3. **차트 7개 섹션** (각각 AI 해석 포함)
4. **AI 종합 진단**: 즉시 조치 / 개선 권고 / 잘하고 있는 점

## Test plan

- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `npx vite build` 빌드 성공
- [x] Overview → "종합 리포트" 버튼 → 리포트 페이지 정상 렌더링
- [x] "PDF로 저장" 버튼 → 브라우저 인쇄 → PDF 다운로드 확인

Closes #31